### PR TITLE
fix: routing bug from /login to /profile

### DIFF
--- a/src/frontend/components/PrivateRoute.jsx
+++ b/src/frontend/components/PrivateRoute.jsx
@@ -5,10 +5,24 @@ const PrivateRoute = ({ children }) => {
   const { user } = useAuthContext();
   const location = useLocation();
 
+  //  this is routeToRedirectAfterSuccessfullLogin
+  let routeToRedirect = location?.pathname;
+
+  // if the user is not logged in, on the linksContainer there is 'Login' Visible and the path is '/profile'.
+
+  // on Clicking it, the user is directed towards the login Page & "state : '/profile' " is passed to the loginPage.
+  // and after successful login. user is redirected to profile page and "logout button" is visible.
+
+  //  this doesnot provide good UX.
+
+  //  so if there is no user data in AuthContext (i.e. user is not logged in) and the route is '/profile', user should come to '/' (home page), so I am passing '/' as state to the Login page.
+
+  if (routeToRedirect === '/profile' && !user) {
+    routeToRedirect = '/';
+  }
+
   if (!user) {
-    return (
-      <Navigate to='/login' state={{ from: location?.pathname }}></Navigate>
-    );
+    return <Navigate to='/login' state={{ from: routeToRedirect }}></Navigate>;
   }
 
   return children;

--- a/src/frontend/pages/LoginPage.jsx
+++ b/src/frontend/pages/LoginPage.jsx
@@ -32,53 +32,6 @@ const LoginPage = () => {
     setUserInputs({ ...userInputs, [e.target.name]: e.target.value });
   };
 
-  // previous code commented 👇
-
-  // const handleLogin = async () => {
-  //   setIsFormLoading(true);
-  //   try {
-  //     const data = await loginUserService(userInputs);
-  //     // update AuthContext with userData
-  //     updateUserAuth(data);
-  //     // show success toast
-  //     toastHandler(ToastType.Success, `Welcome ${data.username} 😎`);
-  //     // if user comes from typing '/login' at the url, redirect it to '/'
-  //     navigate(locationOfLogin?.state?.from ?? '/');
-  //   } catch (error) {
-  //     // console.log(error.response.status);
-  //     // not registered !!
-  //     toastHandler(
-  //       ToastType.Error,
-  //       error.response.data.errors[0].split('.')[0]
-  //     );
-
-  //     // not registered, redirect it to signup !!
-  //     navigate('/signup');
-  //   }
-  // };
-
-  // const handleGuestLogin = async () => {
-  //   setUserInputs(testUser);
-  //   setIsFormLoading(true);
-  //   try {
-  //     const data = await loginUserService(testUser);
-
-  //     // update AuthContext with testUser data
-  //     updateUserAuth(data);
-  //     // show success toast
-  //     toastHandler(ToastType.Success, `Welcome ${data.username} 😎`);
-  //     // if user comes from typing '/login' at the url, redirect it to '/'
-  //     navigate(locationOfLogin?.state?.from ?? '/');
-  //     return;
-  //   } catch (error) {
-  //     // console.log(error.response.status);
-  //     toastHandler(
-  //       ToastType.Error,
-  //       error.response.data.errors[0].split('.')[0]
-  //     );
-  //   }
-  // };
-
   const handleSubmit = async (e, clickType) => {
     e.preventDefault();
     const isGuestClick = clickType === userType.GuestClick;
@@ -104,22 +57,9 @@ const LoginPage = () => {
     } catch (error) {
       // console.log(error.response.status);
       toastHandler(ToastType.Error, error.response.data.errors[0]);
-
-      if (!isGuestClick) {
-        // not registered, redirect it to signup !!
-
-        // user journey
-        // '/wishlist' (protectedRoute) -->
-        // '/login' (login fails, so user should sign up) -->
-        // '/signup' after successful signup -->
-        // '/wishlist'
-
-        // if the non-registered user comes from wishlist and if his login fails, then pass that '/wishlist' state from loginPage's state to the signup page state, so the signup page can access it and after successful signup, and user goes to wishlist..
-        navigate('/signup', {
-          state: { from: locationOfLogin?.state?.from ?? '/' },
-        });
-      }
     }
+
+    setIsFormLoading(false);
   };
 
   return (
@@ -166,9 +106,29 @@ const LoginPage = () => {
         <Loader isLoadingState={isFormLoading} text='Login as a guest' />
       </button>
 
+      {/*
+        * user journey
+        * '/wishlist' (protectedRoute) -->  
+        * '/login' (comes to login page, but thinks to sign up)
+        * clicks Link to sign up
+        * '/signup' after successful signup -->
+        * '/wishlist'
+
+        // if the non-registered user comes from wishlist and then user decides to signup, clicks the link of signup, then pass that '/wishlist' state from loginPage's state to the signup page state, so the signup page can access it and after successful signup, and user goes to wishlist..
+
+        // (locationOfLogin?.state?.from) 
+        // i.e. passing loginPage State to SignupPage State
+      */}
+
       <div>
         <span>
-          Don't have an account? <Link to='/signup'>sign up</Link>
+          Don't have an account?{' '}
+          <Link
+            to='/signup'
+            state={{ from: locationOfLogin?.state?.from ?? '/' }}
+          >
+            sign up
+          </Link>
         </span>
       </div>
     </LoginAndSignupLayout>

--- a/src/frontend/pages/SignupPage.jsx
+++ b/src/frontend/pages/SignupPage.jsx
@@ -41,7 +41,9 @@ const SignupPage = () => {
     }
 
     const { email, firstName, lastName, passwordMain: password } = userInputs;
+
     setIsSignupFormLoading(true);
+
     try {
       const data = await signupService({
         email,
@@ -69,7 +71,6 @@ const SignupPage = () => {
     }
 
     setIsSignupFormLoading(false);
-    // console.log('Create New Account', { userInputs });
   };
 
   return (


### PR DESCRIPTION
user journey
*  '/wishlist' (protectedRoute) -->  
*  '/login' (comes to login page, but thinks to sign up)
*  clicks Link to sign up
*  '/signup' after successful signup -->
* '/wishlist'

if the non-registered user comes from wishlist and then user decides to signup, clicks the link of signup, then pass that '/wishlist' state from loginPage's state to the signup page state, so the signup page can access it and after successful signup, and user goes to wishlist.